### PR TITLE
fix sign bit, return as Int, not Buf

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -21,5 +21,5 @@
     "Test",
     "Test::META"
   ],
-  "version" : "0.0.1"
+  "version" : "0.1.0"
 }

--- a/README.md
+++ b/README.md
@@ -22,15 +22,25 @@ Digest::MurmurHash3 is a [MurmurHash3](https://github.com/aappleby/smhasher) has
 METHODS
 =======
 
-murmurhash3_32(Str $key, uint32 $seed) returns Buf
+murmurhash3_32(Str $key, uint32 $seed) returns Int
 --------------------------------------------------
 
-Calculates 32-bit hash, and returns as Buf.
+Calculates 32-bit hash, and returns as Int.
 
-murmurhash3_128(Str $key, uint32 $seed) returns Buf
----------------------------------------------------
+MurmurHash3_32_hex(Str $key, uint32 $seed) returns Buf
+------------------------------------------------------
 
-Calculates 128-bit hash, and returns as Buf.
+Calculates 32-bit hash, and returns as Buf. A hex string can be obtained with `.unpack("H4")`.
+
+murmurhash3_128(Str $key, uint32 $seed) returns Array[Int]
+----------------------------------------------------------
+
+Calculates 128-bit hash, and returns as Array[Int] with length of 4.
+
+murmurhash3_128_hex(Str $key, uint32 $seed) returns Buf
+-------------------------------------------------------
+
+Calculates 128-bit hash, and returns as Buf. A hex string can be obtained with `.unpack("H16")`.
 
 AUTHOR
 ======

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -14,8 +14,15 @@ all: %DESTDIR% %DESTDIR%/libmurmurhash3%SO%
 %DESTDIR%/libmurmurhash3%O%: libmurmurhash3.c
 	%CC% -c %CCSHARED% %CCFLAGS% %CCOUT% %DESTDIR%/libmurmurhash3%O% libmurmurhash3.c
 
-test: %DESTDIR%/libmurmurhash3%SO%
+test: %DESTDIR%/libmurmurhash3-test %DESTDIR%/libmurmurhash3%SO%
+	%DESTDIR%/libmurmurhash3-test
 	cd ../ && prove
+
+%DESTDIR%/libmurmurhash3-test: %DESTDIR%/MurmurHash3%O% %DESTDIR%/libmurmurhash3-test%O%
+	%CC% %CCSHARED% %CCFLAGS% %CCOUT% %DESTDIR%/libmurmurhash3-test %DESTDIR%/MurmurHash3%O% %DESTDIR%/libmurmurhash3-test%O%
+
+%DESTDIR%/libmurmurhash3-test%O%:
+	%CC% -c %CCSHARED% %CCFLAGS% %CCOUT% %DESTDIR%/libmurmurhash3-test%O% libmurmurhash3-test.c
 
 clean:
 	-rm -rf %DESTDIR%

--- a/src/libmurmurhash3-test.c
+++ b/src/libmurmurhash3-test.c
@@ -1,0 +1,45 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "MurmurHash3.h"
+
+void test_MurmurHash3_x86_32() {
+    const char * key = "hogefugafoobar";
+    int len = 14;
+    uint32_t seed = 12345678;
+    uint32_t result;
+
+    printf("Testing %s ... ", __func__);
+
+    MurmurHash3_x86_32(key, len, seed, &result);
+
+    assert(result == 463552099);
+
+    printf("Done\n");
+}
+
+void test_MurmurHash3_x86_128() {
+    const char * key = "hogefugafoobar";
+    int len = 14;
+    uint32_t seed = 12345678;
+    uint32_t result[4];
+
+    printf("Testing %s ... ", __func__);
+
+    MurmurHash3_x86_128(key, len, seed, &result);
+
+    assert(result[0] == 1512736128);
+    assert(result[1] == 3528938480);
+    assert(result[2] == 3633978259);
+    assert(result[3] == 481906499);
+
+    printf("Done\n");
+}
+
+int main() {
+
+    test_MurmurHash3_x86_32();
+    test_MurmurHash3_x86_128();
+
+    return 0;
+}

--- a/t/02-murmurhash.t
+++ b/t/02-murmurhash.t
@@ -7,17 +7,45 @@ my Str $key  = "hogefugafoobar";
 my Int $seed = 12345678;
 
 subtest {
-    my Buf $result = murmurhash3_32($key, $seed);
 
-    is $result.unpack('H4'), '633ea11b';
+    # ~0 for type uint32 should be 4294967295
+    # but turns out to be -1 in CArray[uint32]!
+    is Digest::MurmurHash3::fix-sign-bit(-1), 4294967295;
+
+}, 'Test fix-sign-bit';
+
+subtest {
+    my Int $result = murmurhash3_32($key, $seed);
+
+    is $result, 463552099;
 
 }, 'Test murmurhash3_32';
 
 subtest {
-    my Buf $result = murmurhash3_128($key, $seed);
+    my Buf $result = murmurhash3_32_hex($key, $seed);
 
-    is $result.unpack('H16'), '80852a5a10aca8ad6de465a7434fb91c';
+    is $result.unpack('H4'), '633ea11b';
+
+}, 'Test murmurhash3_32_hex';
+
+subtest {
+    my Int @result = murmurhash3_128($key, $seed);
+
+    is @result.elems, 4;
+    is-deeply @result, Array[Int].new(
+        1512736128,
+        3528938480,
+        3633978259,
+        481906499,
+    );
 
 }, 'Test murmurhash3_128';
+
+subtest {
+    my Buf $result = murmurhash3_128_hex($key, $seed);
+
+    is $result.unpack('H16'), '80852a5af05357d2931b9ad8434fb91c';
+
+}, 'Test murmurhash3_128_hex';
 
 done-testing;


### PR DESCRIPTION
- Bump version to 0.1.0
- Correctly handle unsigned int
  - CArray[uint32] creates signed int but we need unsigned
- Breaking chain:
  - Separate murmurhash3_32 into:
    - murmurhash3_32() returns Int
    - murmurhash3_32_hex() returns Buf
  - Separate murmurhash3_128 into:
    - murmurhash3_128() return Array[Int]
    - murmurhash3_128_hex() returns Buf
