### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -11,6 +11,7 @@
   ],
   "description" : "MurmurHash3 implementation for Perl 6",
   "name" : "Digest::MurmurHash3",
+  "license" : "Artistic-2.0",
   "perl" : "6.c",
   "provides" : {
     "Digest::MurmurHash3" : "lib/Digest/MurmurHash3.pm6"


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license